### PR TITLE
Fix space characters for emoji name

### DIFF
--- a/src/upload-emoji.js
+++ b/src/upload-emoji.js
@@ -20,7 +20,7 @@ export default function uploadEmoji (file, callback = NO_OP) {
   const timestamp = Date.now() / 1000;  
   const version = versionUid ? versionUid.substring(0, 8) : 'noversion';
   const id = uuid.v4();
-  const name = file.name.split('.')[0].toLowerCase();
+  const name = file.name.split('.')[0].toLowerCase().replaceAll(' ', '-');
 
   const formData = new FormData();
   formData.append('name', name);


### PR DESCRIPTION
## Problem

Space characters are passed to the Slack form in the file name causing an error.

## Solution

Used `replaceAll` to swap spaces for dashes. I chose dashes as opposed to underscores because slack emoji indexing works nicer with dashes.